### PR TITLE
Added custom Painter support & better margin handling

### DIFF
--- a/lib/src/image_batch_compiler.dart
+++ b/lib/src/image_batch_compiler.dart
@@ -14,9 +14,14 @@ import 'package:flame_tiled/flame_tiled.dart';
 /// add(ground);
 /// ```
 class ImageBatchCompiler {
-  PositionComponent compileMapLayer(
-      {required RenderableTiledMap tileMap, List<String>? layerNames}) {
+  PositionComponent compileMapLayer({
+    required RenderableTiledMap tileMap,
+    List<String>? layerNames,
+    Paint? paint,
+  }) {
     layerNames ??= [];
+    paint ??= Paint();
+
     _unlistedLayers(tileMap, layerNames).forEach((element) {
       element.visible = false;
     });
@@ -40,7 +45,7 @@ class ImageBatchCompiler {
         tileMap.map.height * tileMap.map.tileHeight);
     picture.dispose();
 
-    return _ImageComponent(image);
+    return _ImageComponent(image, paint);
   }
 
   static List<Layer> _unlistedLayers(
@@ -56,12 +61,13 @@ class ImageBatchCompiler {
 }
 
 class _ImageComponent extends PositionComponent {
-  _ImageComponent(this.image);
+  _ImageComponent(this.image, this.paint);
 
   final Image image;
+  final Paint paint;
 
   @override
   void render(Canvas canvas) {
-    canvas.drawImage(image, const Offset(0, 0), Paint());
+    canvas.drawImage(image, const Offset(0, 0), paint);
   }
 }

--- a/lib/src/tile_processor.dart
+++ b/lib/src/tile_processor.dart
@@ -86,11 +86,21 @@ class TileProcessor {
       final row = ((tileId + 0.9) ~/ maxColumns) + 1;
       final column = (tileId + 1) - ((row - 1) * maxColumns);
 
-      cachedSprite = Sprite(spriteSheetImg,
-          srcPosition: Vector2(((column - 1) * tileset.tileWidth!).toDouble(),
-              ((row - 1) * tileset.tileHeight!).toDouble()),
-          srcSize: Vector2(
-              tileset.tileWidth!.toDouble(), tileset.tileHeight!.toDouble()));
+      final margin = tileset.margin;
+      final spacing = tileset.spacing;
+      final tileWidth = tileset.tileWidth!;
+      final tileHeight = tileset.tileHeight!;
+
+      final srcX = margin + (column - 1) * (tileWidth + spacing);
+      final srcY = margin + (row - 1) * (tileHeight + spacing);
+
+      cachedSprite = Sprite(
+        spriteSheetImg,
+        srcPosition: Vector2(srcX.toDouble(), srcY.toDouble()),
+        srcSize: Vector2(
+            tileWidth.toDouble() - 0.0001, tileHeight.toDouble() - 0.0001),
+      );
+
       _spriteCache[key] = cachedSprite;
     }
     return cachedSprite;
@@ -124,9 +134,12 @@ class TileProcessor {
   int _maxColumns(TiledImage image) {
     final maxWidth = image.width;
     final tileWidth = tileset.tileWidth;
+    final margin = tileset.margin;
+    final spacing = tileset.spacing;
+
     if (maxWidth == null || tileWidth == null) throw 'No tile dimensions';
 
-    return maxWidth ~/ tileWidth;
+    return (maxWidth - 2 * margin + spacing) ~/ (tileWidth + spacing);
   }
 
   Image? _getImageCache(String image) {


### PR DESCRIPTION
This PR makes two key improvements:

1. Now you can pass a specific `Painter` to `ImageBatchCompiler`, giving more control over how tiles are drawn. This may be useful for effects like shaders or special rendering tweaks (e.g. changing the default FilterQuality.)

2. `TileProcessor` now properly respects the `margin` and `spacing` settings from the tile set.

Let me know if any adjustments are needed! 🚀