### PR TITLE
Add setOffsetCorrection = 0.0001 parameter for correction sprite size

### DIFF
--- a/lib/src/animation_batch_compiler.dart
+++ b/lib/src/animation_batch_compiler.dart
@@ -30,10 +30,10 @@ class AnimationBatchCompiler {
   List<Vector2> positions = [];
   final Completer _completer = Completer();
 
-  Future addTile(Vector2 position, TileProcessor tileProcessor, {bool useRelativePath = false}) async {
+  Future addTile(Vector2 position, TileProcessor tileProcessor, {bool useRelativePath = false, double setOffsetCorrection = 0.0001}) async {
     if (animation == null && _loading == false) {
       _loading = true;
-      animation = await tileProcessor.getSpriteAnimation(useRelativePath: useRelativePath);
+      animation = await tileProcessor.getSpriteAnimation(useRelativePath: useRelativePath, setOffsetCorrection: setOffsetCorrection);
       if (animation == null) {
         _loading = false;
       } else {

--- a/lib/src/tile_processor.dart
+++ b/lib/src/tile_processor.dart
@@ -64,7 +64,7 @@ class TileProcessor {
     _imageCache.clear();
   }
 
-  Future<Sprite> getSprite({int tileId = -1, bool useRelativePath = false}) async {
+  Future<Sprite> getSprite({int tileId = -1, bool useRelativePath = false, double setOffsetCorrection = 0.0001}) async {
     if (tileId == -1) {
       tileId = tile.localId;
     }
@@ -104,7 +104,7 @@ class TileProcessor {
         spriteSheetImg,
         srcPosition: Vector2(srcX.toDouble(), srcY.toDouble()),
         srcSize: Vector2(
-            tileWidth.toDouble() - 0.0001, tileHeight.toDouble() - 0.0001),
+            tileWidth.toDouble() - setOffsetCorrection, tileHeight.toDouble() - setOffsetCorrection),
       );
 
       _spriteCache[key] = cachedSprite;
@@ -112,7 +112,7 @@ class TileProcessor {
     return cachedSprite;
   }
 
-  Future<SpriteAnimation?> getSpriteAnimation({bool useRelativePath = false}) async {
+  Future<SpriteAnimation?> getSpriteAnimation({bool useRelativePath = false, double setOffsetCorrection = 0.0001}) async {
     final image = tileset.image;
     if (image == null) throw 'Cant load sprite without image';
 
@@ -126,7 +126,7 @@ class TileProcessor {
       final List<Sprite> spriteList = [];
       final List<double> stepTimes = [];
       for (final frame in tile.animation) {
-        final sprite = await getSprite(tileId: frame.tileId, useRelativePath: useRelativePath);
+        final sprite = await getSprite(tileId: frame.tileId, useRelativePath: useRelativePath, setOffsetCorrection: setOffsetCorrection);
         spriteList.add(sprite);
         stepTimes.add(frame.duration / 1000);
       }


### PR DESCRIPTION
Hi, this fork I have to create another parameter for correction sprite size if the tile in the edge of image.

TileMap ex:
<img width="1241" height="608" alt="image" src="https://github.com/user-attachments/assets/dab0455c-669b-494e-a298-8755b69bb735" />

when I render if I do not set correction parameter : 
<img width="444" height="211" alt="image" src="https://github.com/user-attachments/assets/c029c092-6048-4591-907e-f0f1954fb605" />

this because sprite size always subtract with 0.0001 
<img width="521" height="140" alt="image" src="https://github.com/user-attachments/assets/a7c90059-35f3-4790-9f46-a0e4a5773f52" />

that's way I add parameter to choose need correction or not.  default value is 0.0001
here is the result : 
<img width="458" height="207" alt="image" src="https://github.com/user-attachments/assets/43d6e387-14de-4bb9-8d6c-cd38cb47d2bc" />

hope you merge this PR. thanks.